### PR TITLE
activate Reproducible Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -760,6 +760,7 @@
     <!-- ================================================ -->
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
     <skin.version>1.0.3</skin.version>
     <org.apache.directory.checkstyle-configuration.version>2.0.1</org.apache.directory.checkstyle-configuration.version>
   </properties>
@@ -1010,7 +1011,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.2</version>
+          <version>5.1.3</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
see https://maven.apache.org/guides/mini/guide-reproducible-builds.html

ideally, when using this POM as a parent POM, creating a separate `project.build.outputTimestamp` property in every subproject will provide a distinct value in each releases subproject

please wait before merging this PR: maven-bundle-plugin 5.1.3 will be released only in a few days https://issues.apache.org/jira/browse/FELIX-6404